### PR TITLE
[protobuf] Include %license also in protobuf-lite. JB#55991

### DIFF
--- a/rpm/protobuf.spec
+++ b/rpm/protobuf.spec
@@ -135,6 +135,7 @@ find %{buildroot} -type f -name "*.la" -exec rm -f {} \;
 
 %files lite
 %defattr(-, root, root, -)
+%license LICENSE
 %{_libdir}/libprotobuf-lite.so.*
 
 %files lite-devel


### PR DESCRIPTION
With -lite being alternative to the full installation, let's include
the license also there.

@Tomin1 @mlehtima 